### PR TITLE
Add GitHub action to run eslint on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'build/**'
+      - 'css/**'
+      - 'images/**'
+      - 'projects/**'
+      - 'resources/**'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+
+      - name: === Lint testing ===
+        run: npm run lint


### PR DESCRIPTION
Related issue: #10 

**Description**

Running the linter as part of the continuous integration process will help ensure a consistent coding style and possibly catch unforeseen bugs
